### PR TITLE
refactor!: Async Resolvers and DataSource fixes #16

### DIFF
--- a/packages/apollo-datasource/__tests__/test-apollo-ds.ts
+++ b/packages/apollo-datasource/__tests__/test-apollo-ds.ts
@@ -16,22 +16,22 @@ describe("apollo-data-source", () => {
         pagerById = new ApolloDataSourcePager({dataSource: new ArrayDataSource(data)});
     });
 
-    test("forward-totalCount", () => {
-        const connection = pagerById.forwardResolver({"first": 10});
+    test("forward-totalCount", async () => {
+        const connection = await pagerById.forwardResolver({"first": 10});
         expect(connection.totalCount).toBe(100);
     });
 
-    test("backward-totalCount", () => {
-        const connection = pagerById.backwardResolver({"last": 10});
+    test("backward-totalCount", async () => {
+        const connection = await pagerById.backwardResolver({"last": 10});
         expect(connection.totalCount).toBe(100);
     });
-    test("backward-out-of-range", () => {
-        const connection = pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(1)});
+    test("backward-out-of-range", async () => {
+        const connection = await pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(1)});
         expect(connection.edges).toHaveLength(0);
     });
 
-    test("backward-last-after", () => {
-        const connection = pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(80)});
+    test("backward-last-after", async () => {
+        const connection = await pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(80)});
         expect(connection.edges).toHaveLength(10);
         expect(connection.edges[0].node.id).toBe(79);
         expect(connection.edges[9].node.id).toBe(70);

--- a/packages/apollo-datasource/src/ApolloDataSourcePager.ts
+++ b/packages/apollo-datasource/src/ApolloDataSourcePager.ts
@@ -16,7 +16,7 @@ export class ApolloDataSourcePager<TContext> extends DataSource<TContext> implem
         this.typeDefs = this.pager.typeDefs;
     }
 
-    backwardResolver(args: any): Connection {
+    async backwardResolver(args: any): Promise<Connection> {
         return this.pager.backwardResolver(args);
     }
 
@@ -30,7 +30,7 @@ export class ApolloDataSourcePager<TContext> extends DataSource<TContext> implem
         return this.pager.edgeObject(node);
     }
 
-    forwardResolver(args: any): Connection {
+    async forwardResolver(args: any): Promise<Connection> {
         return this.pager.forwardResolver(args);
     }
 

--- a/packages/core/__tests__/test-array-ds-pager.ts
+++ b/packages/core/__tests__/test-array-ds-pager.ts
@@ -23,17 +23,17 @@ describe("array-ds-by-id", () => {
         pagerById = new DataSourcePager({dataSource: new ArrayDataSource(data)});
     });
 
-    test("forward-totalCount", () => {
-        const connection = pagerById.forwardResolver({"first": 10});
+    test("forward-totalCount", async () => {
+        const connection = await pagerById.forwardResolver({"first": 10});
         expect(connection.totalCount).toBe(100);
     });
-    test("forward-out-of-range", () => {
-        const connection = pagerById.forwardResolver({"first": 10, "after": pagerById.cursor.encode(100)});
+    test("forward-out-of-range", async () => {
+        const connection = await pagerById.forwardResolver({"first": 10, "after": pagerById.cursor.encode(100)});
         expect(connection.edges).toHaveLength(0);
     });
 
-    test("forward-first-only", () => {
-        const connection = pagerById.forwardResolver({"first": 10});
+    test("forward-first-only", async () => {
+        const connection = await pagerById.forwardResolver({"first": 10});
         expect(connection.edges).toHaveLength(10);
         expect(connection.edges[0].node.id).toBe(1);
         expect(connection.edges[9].node.id).toBe(10);
@@ -41,8 +41,8 @@ describe("array-ds-by-id", () => {
         expect(connection.pageInfo.hasNextPage).toBe(true);
         expect(connection.pageInfo.hasPreviousPage).toBe(false);
     });
-    test("forward-first-after", () => {
-        const connection = pagerById.forwardResolver({"first": 10, "after": pagerById.cursor.encode(20)});
+    test("forward-first-after", async () => {
+        const connection = await pagerById.forwardResolver({"first": 10, "after": pagerById.cursor.encode(20)});
         expect(connection.edges).toHaveLength(10);
         expect(connection.edges[0].node.id).toBe(21);
         expect(connection.edges[9].node.id).toBe(30);
@@ -50,8 +50,8 @@ describe("array-ds-by-id", () => {
         expect(connection.pageInfo.hasNextPage).toBe(true);
         expect(connection.pageInfo.hasPreviousPage).toBe(true);
     });
-    test("forward-first-after-last", () => {
-        const connection = pagerById.forwardResolver({"first": 10, "after": pagerById.cursor.encode(90)});
+    test("forward-first-after-last", async () => {
+        const connection = await pagerById.forwardResolver({"first": 10, "after": pagerById.cursor.encode(90)});
         expect(connection.edges).toHaveLength(10);
         expect(connection.edges[0].node.id).toBe(91);
         expect(connection.edges[9].node.id).toBe(100);
@@ -62,17 +62,17 @@ describe("array-ds-by-id", () => {
 
     /* Backward Tests */
 
-    test("backward-totalCount", () => {
-        const connection = pagerById.backwardResolver({"last": 10});
+    test("backward-totalCount", async () => {
+        const connection = await pagerById.backwardResolver({"last": 10});
         expect(connection.totalCount).toBe(100);
     });
-    test("backward-out-of-range", () => {
-        const connection = pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(1)});
+    test("backward-out-of-range", async () => {
+        const connection = await pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(1)});
         expect(connection.edges).toHaveLength(0);
     });
 
-    test("backward-last-after", () => {
-        const connection = pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(80)});
+    test("backward-last-after", async () => {
+        const connection = await pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(80)});
         expect(connection.edges).toHaveLength(10);
         expect(connection.edges[0].node.id).toBe(79);
         expect(connection.edges[9].node.id).toBe(70);
@@ -80,8 +80,8 @@ describe("array-ds-by-id", () => {
         expect(connection.pageInfo.hasNextPage).toBe(true);
         expect(connection.pageInfo.hasPreviousPage).toBe(true);
     });
-    test("backward-last-after-last", () => {
-        const connection = pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(11)});
+    test("backward-last-after-last", async () => {
+        const connection = await pagerById.backwardResolver({"last": 10, "before": pagerById.cursor.encode(11)});
         expect(connection.edges).toHaveLength(10);
         expect(connection.edges[0].node.id).toBe(10);
         expect(connection.edges[9].node.id).toBe(1);
@@ -98,13 +98,13 @@ describe("array-ds-by-date", () => {
         pager = new DataSourcePager({dataSource: new ArrayDataSource(data, "published")});
     });
 
-    test("forward-totalCount", () => {
-        const connection = pager.forwardResolver({"first": 10});
+    test("forward-totalCount", async () => {
+        const connection = await pager.forwardResolver({"first": 10});
         expect(connection.totalCount).toBe(100);
     });
 
-    test("forward-first-only", () => {
-        const connection = pager.forwardResolver({"first": 10});
+    test("forward-first-only", async () => {
+        const connection = await pager.forwardResolver({"first": 10});
         expect(connection.edges).toHaveLength(10);
         expect(connection.edges[0].node.id).toBe(1);
         expect(connection.edges[9].node.id).toBe(10);
@@ -113,8 +113,8 @@ describe("array-ds-by-date", () => {
         expect(connection.pageInfo.hasPreviousPage).toBe(false);
     });
 
-    test("backward-last-only", () => {
-        const connection = pager.backwardResolver({"last": 10});
+    test("backward-last-only", async () => {
+        const connection = await pager.backwardResolver({"last": 10});
         expect(connection.edges).toHaveLength(10);
         expect(connection.edges[0].node.id).toBe(100);
         expect(connection.edges[9].node.id).toBe(91);
@@ -134,22 +134,22 @@ describe("array-ds-filter", () => {
         });
     });
 
-    test("title", () => {
-        const connection = pager.forwardResolver({"first": 10, "title": "Title 5"});
+    test("title", async () => {
+        const connection = await pager.forwardResolver({"first": 10, "title": "Title 5"});
         expect(connection.totalCount).toBe(1);
         expect(connection.edges[0].node.id).toBe(5);
     });
-    test("author", () => {
+    test("author", async () => {
         const desiredAuthor = "Author 5";
-        const connection = pager.forwardResolver({"first": 10, "author": desiredAuthor});
+        const connection = await pager.forwardResolver({"first": 10, "author": desiredAuthor});
         expect(connection.totalCount).toBe(10);
         connection.edges.forEach((edge) => {
             expect(edge.node.author).toBe(desiredAuthor);
         })
     });
-    test("validation-author", () => {
+    test("validation-author", async () => {
         const desiredAuthor = "Author 5";
-        const connection = pager.forwardResolver({"first": 10, "author": desiredAuthor});
+        const connection = await pager.forwardResolver({"first": 10, "author": desiredAuthor});
         expect(connection.totalCount).toBe(10);
         connection.edges.forEach((edge) => {
             expect(edge.node.author).toBe(desiredAuthor);
@@ -168,17 +168,17 @@ describe("array-ds-validation", () => {
         });
     });
 
-    test("validation-disabled", () => {
+    test("validation-disabled", async () => {
         const pagerNoValidation = new DataSourcePager({dataSource: new ArrayDataSource(data, "id", filter)});
-        const connection = pagerNoValidation.forwardResolver({"first": 10, "title": "BAD-TITLE"});
+        const connection = await pagerNoValidation.forwardResolver({"first": 10, "title": "BAD-TITLE"});
         expect(connection.edges).toHaveLength(0);
-        const connectionBack = pagerNoValidation.backwardResolver({"last": 10, "title": "BAD-TITLE"});
+        const connectionBack = await pagerNoValidation.backwardResolver({"last": 10, "title": "BAD-TITLE"});
         expect(connectionBack.edges).toHaveLength(0);
     });
 
     test("validation-title", () => {
         const tested = () => pager.forwardResolver({"first": 10, "title": "BAD-TITLE"});
-        expect(tested).toThrow("Title BAD-TITLE not exists");
+        return expect(tested).rejects.toStrictEqual(new Error("Title BAD-TITLE not exists"));
     });
     test("validation-array-title", () => {
         const pagerValidationArray = new DataSourcePager({
@@ -187,12 +187,19 @@ describe("array-ds-validation", () => {
             validateBackwardArgs: [validation]
         });
         const tested = () => pagerValidationArray.forwardResolver({"first": 10, "title": "BAD-TITLE"});
-        expect(tested).toThrow("Title BAD-TITLE not exists");
+        return expect(tested).rejects.toStrictEqual(new Error("Title BAD-TITLE not exists"));
+    });
+    test("validation-array-title-back", () => {
+        const pagerValidationArray = new DataSourcePager({
+            dataSource: new ArrayDataSource(data, "id", filter),
+            validateForwardArgs: [validation],
+            validateBackwardArgs: [validation]
+        });
         const testedBack = () => pagerValidationArray.backwardResolver({"last": 10, "title": "BAD-TITLE"});
-        expect(testedBack).toThrow("Title BAD-TITLE not exists");
+        return expect(testedBack).rejects.toStrictEqual(new Error("Title BAD-TITLE not exists"));
     });
     test("validation-author", () => {
         const tested = () => pager.backwardResolver({"last": 10, "author": "BAD-AUTHOR"});
-        expect(tested).toThrow("Author BAD-AUTHOR not exists");
+        return expect(tested).rejects.toStrictEqual(new Error("Author BAD-AUTHOR not exists"));
     });
 });

--- a/packages/core/__tests__/test-array-ds.ts
+++ b/packages/core/__tests__/test-array-ds.ts
@@ -17,10 +17,13 @@ describe("array-ds", () => {
         expect(ds.getId({"id2": 1})).toBe(1);
     })
 
-    test("id-bad-type", () => {
+    test("after-id-bad-type", () => {
         const ds = new ArrayDataSource([{"idboolean": true}, {"idboolean": true}, {"idboolean": true}], "idboolean");
-        expect(() => ds.after(1, 10, {first: 10})).toThrow("Type boolean is not supported");
-        expect(() => ds.before(1, 10, {last: 10})).toThrow("Type boolean is not supported");
+        return expect(ds.after(1, 10, {first: 10})).rejects.toStrictEqual(new Error("Type boolean is not supported"));
+    })
+    test("before-id-bad-type", () => {
+        const ds = new ArrayDataSource([{"idboolean": true}, {"idboolean": true}, {"idboolean": true}], "idboolean");
+        return expect(ds.before(1, 10, {last: 10})).rejects.toStrictEqual(new Error("Type boolean is not supported"));
     })
 
 })

--- a/packages/core/src/CursorPagerSpec.ts
+++ b/packages/core/src/CursorPagerSpec.ts
@@ -61,9 +61,9 @@ export interface CursorPager<NodeType, IdType> {
 
     // Main Resolvers
 
-    forwardResolver: (args: ArgsForward | any) => Connection;
+    forwardResolver: (args: ArgsForward | any) => Promise<Connection>;
 
-    backwardResolver: (args: ArgsBackward | any) => Connection;
+    backwardResolver: (args: ArgsBackward | any) => Promise<Connection>;
 
     // Return Objects Helpers
 

--- a/packages/core/src/DataSourcePager.ts
+++ b/packages/core/src/DataSourcePager.ts
@@ -58,36 +58,36 @@ export class DataSourcePager implements CursorPager<any, string | number | Date>
 
     validateForwardArgs?: [validationArgFn];
 
-    forwardResolver(args: ArgsForward | any): Connection {
+    async forwardResolver(args: ArgsForward | any): Promise<Connection> {
         if (this.validateForwardArgs) this.validateForwardArgs.forEach(validation => validation(args));
 
         let afterId;
         if (args.after) afterId = this.cursor.decode(args.after);
 
-        const resultPlusOne = this.dataSource.after(afterId, args.first + 1, args);
+        const resultPlusOne = await this.dataSource.after(afterId, args.first + 1, args);
 
         const hasNextPage = resultPlusOne?.length > args.first;
         const hasPreviousPage = !!args.after;
 
-        const totalCount = this.dataSource.totalCount(args);
+        const totalCount = await this.dataSource.totalCount(args);
 
         return this.connectionObject(resultPlusOne.slice(0, args.first), args, totalCount, hasNextPage, hasPreviousPage);
     }
 
     validateBackwardArgs?: [validationArgFn];
 
-    backwardResolver(args: ArgsBackward | any): Connection {
+    async backwardResolver(args: ArgsBackward | any): Promise<Connection> {
         if (this.validateBackwardArgs) this.validateBackwardArgs.forEach(validation => validation(args));
 
         let beforeId;
         if (args.before) beforeId = this.cursor.decode(args.before);
 
-        const resultPlusOne = this.dataSource.before(beforeId, args.last + 1, args);
+        const resultPlusOne = await this.dataSource.before(beforeId, args.last + 1, args);
 
         const hasNextPage = resultPlusOne?.length > args.last;
         const hasPreviousPage = !!args.before;
 
-        const totalCount = this.dataSource.totalCount(args);
+        const totalCount = await this.dataSource.totalCount(args);
 
         return this.connectionObject(resultPlusOne.slice(0, args.last), args, totalCount, hasNextPage, hasPreviousPage);
     }

--- a/packages/core/src/datasource/ArrayDataSource.ts
+++ b/packages/core/src/datasource/ArrayDataSource.ts
@@ -30,18 +30,18 @@ export class ArrayDataSource<NodeType> extends DataSourceBase<NodeType, number |
         return this.transformNodes(nodes, originalArgs);
     }
 
-    totalCount(originalArgs: ArgsForward | ArgsBackward): number {
+    async totalCount(originalArgs: ArgsForward | ArgsBackward): Promise<number> {
         return this.getNodes(this.nodes, originalArgs).length;
     }
 
-    after(afterId: number | Date | undefined, size: number, originalArgs: ArgsForward): NodeType[] {
+    async after(afterId: number | Date | undefined, size: number, originalArgs: ArgsForward): Promise<NodeType[]> {
         return this.getNodes(this.nodes, originalArgs)
             .sort((a, b) => this.compareNodesId(a, b, true))
             .filter(node => !afterId ? true : this.getId(node) > afterId)
             .slice(0, size);
     }
 
-    before(beforeId: number | Date | undefined, size: number, originalArgs: ArgsBackward): NodeType[] {
+    async before(beforeId: number | Date | undefined, size: number, originalArgs: ArgsBackward): Promise<NodeType[]> {
         return this.getNodes(this.nodes, originalArgs)
             .sort((a, b) => this.compareNodesId(a, b, false))
             .filter(node => !beforeId ? true : this.getId(node) < beforeId)

--- a/packages/core/src/datasource/DataSource.ts
+++ b/packages/core/src/datasource/DataSource.ts
@@ -7,11 +7,11 @@ export interface PagerDataSource<NodeType, IdType> {
 
     getId: (node: NodeType) => IdType;
 
-    totalCount: (originalArgs: ArgsForward | ArgsBackward) => number
+    totalCount: (originalArgs: ArgsForward | ArgsBackward) => Promise<number>
 
-    after: (afterId: IdType | undefined, size: number, originalArgs: ArgsForward) => NodeType[]
+    after: (afterId: IdType | undefined, size: number, originalArgs: ArgsForward) => Promise<NodeType[]>
 
-    before: (beforeId: IdType | undefined, size: number, originalArgs: ArgsBackward) => NodeType[]
+    before: (beforeId: IdType | undefined, size: number, originalArgs: ArgsBackward) => Promise<NodeType[]>
 
 }
 
@@ -26,11 +26,11 @@ export abstract class DataSourceBase<NodeType, IdType> implements PagerDataSourc
         this.idFieldName = idFieldName;
     }
 
-    abstract totalCount(originalArgs: ArgsForward | ArgsBackward): number;
+    abstract totalCount(originalArgs: ArgsForward | ArgsBackward): Promise<number>;
 
-    abstract after(afterId: IdType | undefined, size: number, originalArgs: ArgsForward): any[];
+    abstract after(afterId: IdType | undefined, size: number, originalArgs: ArgsForward): Promise<any[]>;
 
-    abstract before(beforeId: IdType | undefined, size: number, originalArgs: ArgsBackward): any[];
+    abstract before(beforeId: IdType | undefined, size: number, originalArgs: ArgsBackward): Promise<any[]>;
 
     getId(node: any): IdType {
         return node[this.idFieldName];


### PR DESCRIPTION
BREAKING CHANGE: CursorPager interface returns Promise<Connection> to be fully async model. Same for DataSource and its implementations.