### PR TITLE
fix: Use primitive types in PageInfo object

### DIFF
--- a/packages/core/src/CursorPagerSpec.ts
+++ b/packages/core/src/CursorPagerSpec.ts
@@ -26,10 +26,10 @@ export interface Edge {
  * @see https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo.Fields
  */
 export interface PageInfo {
-    hasPreviousPage: Boolean
-    hasNextPage: Boolean
-    startCursor?: String
-    endCursor?: String
+    hasPreviousPage: boolean
+    hasNextPage: boolean
+    startCursor?: string
+    endCursor?: string
 }
 
 /**


### PR DESCRIPTION
fixes #92 