### PR TITLE
feat: encode and decode object IdType

### DIFF
--- a/packages/core/__tests__/test-default-cursor.ts
+++ b/packages/core/__tests__/test-default-cursor.ts
@@ -34,6 +34,12 @@ describe("cursor", () => {
         expect(encoded).toBe(Buffer.from("n_123").toString("base64"));
     });
 
+    test("encode-object", () => {
+        const o = { test: "test" };
+        const encoded = new DefaultCursorEncoderDecoder<Record<string, any>>().encode(o);
+        expect(encoded).toBe(Buffer.from("o_" + JSON.stringify(o)).toString("base64"));
+    });
+
     test("decode-string", () => {
         const decoded = new DefaultCursorEncoderDecoder<string>().decode(Buffer.from("c_test-string").toString("base64"));
         expect(decoded).toBe("test-string");
@@ -55,6 +61,21 @@ describe("cursor", () => {
         const decoded = new DefaultCursorEncoderDecoder<number>().decode(Buffer.from("n_123").toString("base64"));
         expect(decoded).toBe(123);
     });
+
+    test("decode-object", () => {
+        const o = { test: "test" };
+        const decoded = new DefaultCursorEncoderDecoder<Record<string, any>>().decode(Buffer.from("o_" + JSON.stringify(o)).toString("base64"));
+        expect(decoded).toStrictEqual(o);
+    });
+
+    test("decode-object-invalid-json", () => {
+        try {
+            new DefaultCursorEncoderDecoder<number>().decode(Buffer.from("o_xx").toString("base64"));
+        } catch (e) {
+            validateInvalidCursor(e);
+        }
+    });
+    
     test("decode-string-empty", () => {
         try {
             new DefaultCursorEncoderDecoder<number>().decode(Buffer.from("n_").toString("base64"));

--- a/packages/core/src/DefaultCursorEncoderDecoder.ts
+++ b/packages/core/src/DefaultCursorEncoderDecoder.ts
@@ -10,7 +10,8 @@ export class DefaultCursorEncoderDecoder<IdType = string | number | Date> implem
     encode(plainCursor: IdType): string {
         let id = "c_" + plainCursor;
         if (plainCursor instanceof Date) id = "d_" + plainCursor.getTime();
-        if (typeof plainCursor === "number") id = "n_" + plainCursor;
+        else if (typeof plainCursor === "number") id = "n_" + plainCursor;
+        else if (typeof plainCursor === "object") id = "o_" + JSON.stringify(plainCursor);
         return Buffer.from(id).toString("base64");
     }
 
@@ -23,8 +24,13 @@ export class DefaultCursorEncoderDecoder<IdType = string | number | Date> implem
         if (id.startsWith("n_")) return Number(value) as IdType;
         if (id.startsWith("c_")) return value as IdType;
 
+        try {
+            if (id.startsWith("o_")) return JSON.parse(value) as IdType;
+        } catch (e) {
+            // ignore json parsing errors and continue to exception
+        }
+
         throw new GraphQLError("Invalid cursor value", { extensions: { code: "BAD_USER_INPUT" } });
     }
 
 }
-


### PR DESCRIPTION
If the node's id is an object, like in dynamo tables, allow the default encoding/decoding of them without using a custom cursor class