### PR TITLE
Pass args to getId

### DIFF
--- a/packages/core/src/DataSourcePager.ts
+++ b/packages/core/src/DataSourcePager.ts
@@ -170,7 +170,7 @@ export const PagerObject = {
     connectionObject<NodeType, IdType, ArgsForwardType extends ArgsForward, ArgsBackwardType extends ArgsBackward>(
         nodes: any[], args: ArgsForward | ArgsBackward | any, totalCount: number | undefined, hasNextPage: boolean, hasPreviousPage: boolean,
         dataSource: PagerDataSource<NodeType, IdType, ArgsForwardType, ArgsBackwardType>, cursor: CursorEncoderDecoder<IdType>): Connection<NodeType> {
-        const edges = nodes.map(node => this.edgeObject(node, dataSource, cursor))
+        const edges = nodes.map(node => this.edgeObject(node, dataSource, cursor, args))
         const connection = {
             totalCount: totalCount,
             edges,
@@ -184,8 +184,8 @@ export const PagerObject = {
     },
 
     edgeObject<NodeType, IdType, ArgsForwardType extends ArgsForward, ArgsBackwardType extends ArgsBackward>(node: any,
-        dataSource: PagerDataSource<NodeType, IdType, ArgsForwardType, ArgsBackwardType>, cursor: CursorEncoderDecoder<IdType>): Edge<NodeType> {
-        const plainId = dataSource.getId(node);
+        dataSource: PagerDataSource<NodeType, IdType, ArgsForwardType, ArgsBackwardType>, cursor: CursorEncoderDecoder<IdType>, args?: ArgsForwardType | ArgsBackwardType): Edge<NodeType> {
+        const plainId = dataSource.getId(node, args);
         return {
             cursor: cursor.encode(plainId),
             node

--- a/packages/core/src/datasource/DataSource.ts
+++ b/packages/core/src/datasource/DataSource.ts
@@ -5,7 +5,7 @@ import type {ArgsBackward, ArgsForward} from "../CursorPagerSpec";
  */
 export interface PagerDataSource<NodeType, IdType, ArgsForwardType extends ArgsForward, ArgsBackwardType extends ArgsBackward> {
 
-    getId: (node: NodeType) => IdType;
+    getId: (node: NodeType, args?: ArgsForwardType | ArgsBackwardType) => IdType;
 
     totalCount: (originalArgs: ArgsForwardType | ArgsBackwardType) => Promise<number>
 


### PR DESCRIPTION
When calculating cursors, sometimes you need to know information like the type of index being used. Passing `args` through makes this possible