### PR TITLE
chore(deps): modernize TS6/Node24 toolchain and CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,13 @@ jobs:
       MONGOMS_VERSION: "6.0.14"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Checkout all branches and tags
-      - name: "Use NodeJS 20"
+      - name: "Use NodeJS 24"
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       # Build and test
       - run: npm -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 20.x]
+        node-version: [24.x, 22.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:
@@ -31,4 +31,4 @@ jobs:
     - run: npm run build
     - run: npm test
 
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v6

--- a/examples/mongodb/package.json
+++ b/examples/mongodb/package.json
@@ -20,7 +20,7 @@
         "@graphql-pagination/mongodb": "^1.3.1",
         "graphql": "^16.11.0",
         "graphql-tag": "2.12.6",
-        "mongodb": "^6.21.0",
+        "mongodb": "^7.0.0",
         "mongodb-memory-server": "^10.4.3"
     },
     "devDependencies": {
@@ -29,8 +29,7 @@
         "@graphql-codegen/typescript-resolvers": "^3.2.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^18.19.130",
-        "ts-jest": "^29.4.4",
         "ts-node": "^10.9.1",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.0"
     }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-/** @type {import("ts-jest/dist/types").InitialOptionsTsJest} */
+/** @type {import("jest").Config} */
 module.exports = {
     collectCoverage: true,
     coverageDirectory: "coverage",
@@ -17,25 +17,19 @@ module.exports = {
     ],
     transform: {
         "^.+\\.ts$": [
-            "ts-jest",
+            "@swc/jest",
             {
-                tsconfig: {
-                    "types": ["node", "jest"],
-                    "target": "es2022",
-                    "module": "commonjs",
-                    "moduleResolution": "node",
-                    "esModuleInterop": true,
-                    "strict": false,
-                    "noImplicitAny": false,
-                    "noImplicitReturns": true,
-                    "noImplicitOverride": false,
-                    "noFallthroughCasesInSwitch": true,
-                    "noUnusedParameters": true,
-                    "noUnusedLocals": false,
-                    "lib": ["es2022"],
-                    noImplicitAny: false,
+                jsc: {
+                    target: "es2022",
+                    parser: {
+                        syntax: "typescript",
+                        decorators: true
+                    }
                 },
-            },
+                module: {
+                    type: "commonjs"
+                }
+            }
         ],
     }
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "examples/mongodb/"
   ],
   "devDependencies": {
+    "@swc/core": "^1.13.5",
+    "@swc/jest": "^0.2.39",
     "@types/jest": "^30.0.0",
     "eslint": "^8.57.1",
     "eslint-config-standard": "^17.0.0",
@@ -32,8 +34,8 @@
     "jest": "^30.0.0",
     "jest-config": "^30.0.0",
     "jest-junit": "^16.0.0",
-    "lerna": "8.2.4",
-    "ts-jest": "^29.4.4",
-    "typescript": "^5.9.3"
-  }
+    "lerna": "^9.0.0",
+    "typescript": "^6.0.0"
+  },
+  "packageManager": "npm@11.4.1"
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist"
   },
   "include": [

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.130",
-    "mongodb": "^6.21.0",
+    "mongodb": "^7.0.0",
     "mongodb-memory-server": "^11.0.0"
   }
 }

--- a/packages/mongodb/tsconfig.json
+++ b/packages/mongodb/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist"
   },
   "include": [

--- a/packages/sql-knex/tsconfig.json
+++ b/packages/sql-knex/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist"
   },
   "include": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
     "lib": ["es2019"]
   }
 }


### PR DESCRIPTION
Upgrade TypeScript to v6, Lerna to v9, and MongoDB driver to v7 while updating CI to Node 24 and latest checkout/codecov actions. Replace ts-jest with SWC-based Jest transforms and migrate shared tsconfig to Node16 module resolution with explicit package rootDir settings for long-term TypeScript 6+ compatibility.